### PR TITLE
dockerfile: use external balena-cli-docker base image

### DIFF
--- a/app/Dockerfile.template
+++ b/app/Dockerfile.template
@@ -1,40 +1,12 @@
-ARG NODE_VERSION=12.6.0
-
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:${NODE_VERSION}-buster-run
-
-ARG BALENA_CLI_VERSION=12.33.0
-
-# set the SHELL option -o pipefail before RUN with a pipe in
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# set debconf to run non-interactively
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN install_packages \
-    apt-transport-https \
-    build-essential \
-    ca-certificates \
-    curl \
-    git \
-    python \
-    wget
-
-# use the official docker-ce installer that only supports up to buster for now
-RUN curl -fsSL https://get.docker.com | bash
-
-# overlay2 requires a docker volume for graph
-VOLUME /var/lib/docker
-
-# install balena cli
-RUN npm install balena-cli@${BALENA_CLI_VERSION} -g --production --unsafe-perm
+FROM klutchell/balena-cli:12.38.2
 
 WORKDIR /usr/src/app
 
-COPY entry.sh .
+COPY preload.sh .
 
-RUN chmod +x ./entry.sh
+RUN chmod +x ./preload.sh
 
-CMD [ "./entry.sh" ]
+CMD [ "./preload.sh" ]
 
 ENV DOWNLOAD_OS_VERSION latest
 ENV PRELOAD_APP_RELEASE current

--- a/app/preload.sh
+++ b/app/preload.sh
@@ -12,12 +12,6 @@ target_img="${target_img}-${DOWNLOAD_OS_VERSION/+/-}"
 target_img="${target_img}-${PRELOAD_APP_RELEASE}"
 target_img="${target_img}.img"
 
-# start dockerd in the background and wait for startup
-rm -rf /var/run/docker/*
-rm /var/run/docker.sock || true
-dockerd &
-sleep 5
-
 # balena login with api key
 balena login --token "${CLI_API_KEY}"
 

--- a/balena.yml
+++ b/balena.yml
@@ -22,8 +22,6 @@ make those images available for download via http"
     - CONFIG_WIFI_KEY: ''
   defaultDeviceType: "fincm3"
   supportedDeviceTypes:
-    - "raspberry-pi"
-    - "raspberry-pi2"
     - "raspberrypi3"
     - "raspberrypi4-64"
     - "fincm3"


### PR DESCRIPTION
This will save compile time and keep generic balena-cli
and docker install steps in one place.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>